### PR TITLE
Rename docker-composer to docker-compose in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This a comple packge for sis dev environment. To get use of this setup you need the following dependacny installed in you computer
 
-This package have three componants
+This package have four componants
 1. SIS applications
 2. SIS bulk upload application
 3. SIS Dashborad
@@ -12,6 +12,9 @@ Dependencies
 2. Docker Compose
 
 
-To run the application do run docker-composer build && docker-compose up
-
+To run the application do run 
+```
+$ docker-composer build 
+$ docker-compose up
+```
 We have configured the Redis cache server for Experiment of the production envirenment. 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,29 @@
+## Purpose
+<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
+The purpose of this PR is to fix #<issue-number>
+
+## Goals
+<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
+
+## Approach
+<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
+
+### Screenshots
+<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
+
+##  Checklist
+- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
+- [ ] I have read and understood the development best practices guidelines 
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+
+## Related PRs
+<!--- List any other related PRs --> 
+
+## Test environment
+<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
+
+## Learning
+<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->


### PR DESCRIPTION
- Rename run docker-composer to run docker-compose in readme.md
![Screenshot from 2020-03-07 14-40-09](https://user-images.githubusercontent.com/43912578/76140534-92e8cf00-6081-11ea-8909-28fb02a548eb.png)